### PR TITLE
fix: format renovate.json with prettier

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
+  "extends": ["config:recommended"]
 }


### PR DESCRIPTION
## Summary
- `renovate.json` が prettier のフォーマットチェックで warning を出していたため修正
- `extends` 配列を 1 行にまとめて prettier のスタイルに合わせた

## Test plan
- [x] `npx prettier --check .` がパスすることを確認

---
_Generated by [Claude Code](https://claude.ai/code/session_012tKg7M6JreqXugycWrJ8w4)_