### PR TITLE
chore(renovate): wait 14 days after package release

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"]
+  "extends": ["config:recommended"],
+  "minimumReleaseAge": "14 days"
 }


### PR DESCRIPTION
## Summary
- Renovate が新しいパッケージのリリースから 14 日 (2週間) 経過するまで更新 PR を出さないように `minimumReleaseAge: "14 days"` を追加。

## Test plan
- [ ] Renovate のドライラン/次回実行で、リリースから 14 日未満のバージョンは更新候補にならないことを確認する


---
_Generated by [Claude Code](https://claude.ai/code/session_01UHTA3Y3HeAYV4EKyF2dAc9)_