### PR TITLE
fix(codeql): use valid language identifier for TypeScript analysis

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         language:
-          - TypeScript
+          - javascript-typescript
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

- CodeQLが「`language:TypeScript` の設定に問題があるかもしれない」と警告し、最後のスキャンが2025-05-14で止まっていた。
- CodeQLは `TypeScript` を有効な言語IDとして受け付けない。公式の結合IDである `javascript-typescript` に変更し、TypeScript ソースが正しく解析されるように修正した。

## Changes

- `.github/workflows/codeql-analysis.yml`: matrix の language を `TypeScript` → `javascript-typescript`

## Test plan

- [ ] PR上でCodeQLワークフローが正常に起動・完了することを確認
- [ ] Code Scanningの結果が更新されることを確認

---
_Generated by [Claude Code](https://claude.ai/code/session_01UY3rC5RNJV8ApFJbp9KxSW)_