### PR TITLE
fix(devcontainer): migrate prettier feature to devcontainers-extra namespace

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -36,6 +36,6 @@
   },
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {},
-    "ghcr.io/devcontainers-contrib/features/prettier:1": {}
+    "ghcr.io/devcontainers-extra/features/prettier:1": {}
   }
 }


### PR DESCRIPTION
## Summary

Renovate was failing to look up the `ghcr.io/devcontainers-contrib/features/prettier` package with the following warning:

```
Failed to look up docker package ghcr.io/devcontainers-contrib/features/prettier: no-result
```

This is because the `devcontainers-contrib` GitHub organization was renamed/migrated to `devcontainers-extra`, and packages under the old namespace are no longer published. Updating the feature reference in `.devcontainer/devcontainer.json` to the new namespace allows Renovate to resolve the package again.

## Changes

- `.devcontainer/devcontainer.json`: `ghcr.io/devcontainers-contrib/features/prettier:1` → `ghcr.io/devcontainers-extra/features/prettier:1`

## Test plan

- [ ] Confirm the devcontainer still builds successfully with the new feature reference
- [ ] Confirm Renovate no longer reports the lookup warning on the next run

---
_Generated by [Claude Code](https://claude.ai/code/session_01K24x7dLzuStAih6oK9NyvJ)_