### PR TITLE
chore: exclude CHANGELOG.md from prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 dist/
 node_modules/
 coverage/
+CHANGELOG.md


### PR DESCRIPTION
## Summary

- `CHANGELOG.md` を `.prettierignore` に追加し、prettier の対象から除外しました。
- `CHANGELOG.md` は release-please によって自動生成されるため、prettier でフォーマットする必要はありません。

## Test plan

- [ ] `npm run format` 実行時に `CHANGELOG.md` が変更されないことを確認

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdXZ1anREg4MyaayCVjUcc)_