### PR TITLE
chore: exclude CHANGELOG.md from super-linter

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -41,7 +41,7 @@ jobs:
         uses: super-linter/super-linter/slim@9e863354e3ff62e0727d37183162c4a88873df41 # v8.6.0
         env:
           DEFAULT_BRANCH: main
-          FILTER_REGEX_EXCLUDE: dist/**/*
+          FILTER_REGEX_EXCLUDE: (dist/.*|CHANGELOG\.md)
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_ALL_CODEBASE: true
           ESLINT_USE_FLAT_CONFIG: false


### PR DESCRIPTION
## Summary

`.github/workflows/linter.yml` の `FILTER_REGEX_EXCLUDE` を更新し、`CHANGELOG.md` を super-linter の対象から除外しました。`release-please` が自動生成する `CHANGELOG.md` が markdown lint などで弾かれないようにします。

- `dist/**/*` → `(dist/.*|CHANGELOG\.md)` に変更（`FILTER_REGEX_EXCLUDE` は正規表現として評価されるため、ついでに正しい正規表現形式に修正）

## Test plan

- [ ] super-linter ジョブが PASS することを確認
- [ ] `CHANGELOG.md` が lint 対象から除外されていることをログで確認
- [ ] `dist/` 配下のファイルが引き続き除外されていることを確認

https://claude.ai/code/session_014YHKYBj45VLwLQL2qgxd1L

---
_Generated by [Claude Code](https://claude.ai/code/session_014YHKYBj45VLwLQL2qgxd1L)_